### PR TITLE
Code: Disable torque for the follower arm during reset

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -298,6 +298,10 @@ def reset_environment(robot, events, reset_time_s):
     # TODO(alibets): allow for teleop during reset
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
+        
+    # Disable torque
+    for name in robot.follower_arms:
+        robot.follower_arms[name].write("Torque_Enable", 0)
 
     timestamp = 0
     start_vencod_t = time.perf_counter()


### PR DESCRIPTION
<!-- All fields below are required. In rare circumstances, explain why not. -->

<!-- Congrats--a pull request! Here is a template to reflect the workflow in the lab handbook -->
<!--  You can contribute to this template here: https://github.com/TheRARELab/.github/edit/main/.github/pull_request_template.md -->

<!-- Please read/review the workflow docs for a good understanding: https://github.com/TheRARELab/handbook/tree/main/Workflow-->

## Relevant issue 
<!-- There should be an issue that this PR closes, use a keyword (e.g., closes) and the issue number (if within the same repo) or issue URL to link it (e.g., https://github.com/TheRARELab/handbook/issues/4). -->
<!-- Please read GitHub doc for more info: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->

closes https://github.com/TheRARELab/robot-learning-project/issues/144

## Describe/summarize the changes

- Modified reset_environment function to disable the torque of the follower robot.

## Show the changes work or high-quality
<!-- e.g., using photos/videos -->
Video showing the robot's torque being disabled during reset.
https://github.com/user-attachments/assets/497045ee-380a-4c53-9a92-7f3448bc3c95

## PR creator's general checklist

- [x] I have read, understood, and followed the [branch-based coding workflow](https://github.com/TheRARELab/handbook/blob/main/Workflow/Code%20and%20Digital%20Artifacts.md#follow-branch-based-coding-workflow), including single-purpose branch and single-purpose PR
- [x] I have [routed lab GitHub notifications to my usf.edu inbox](https://github.com/TheRARELab/handbook/blob/main/Workflow/Code%20and%20Digital%20Artifacts.md#route-lab-github-notifications-to-usfedu-inbox) to receive email notifications and will act in time
- [x] I have [watched all repos under my GitHub team and set it to watch new repos automatically](https://github.com/TheRARELab/handbook/blob/main/Workflow/Code%20and%20Digital%20Artifacts.md#watch-all-repos-under-your-team--new-repos-automatically) 

## PR creator's self-review checklist
<!-- Finally, make sure to do the following and check them off (Doc: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists) -->

- [x] I have summarized the changes in the title, which is not the space-separated branch name.
- [x] I have included only the files and lines relevant to this change.
- [x] I have reviewed each change at the word level to ensure high-quality work.
- [ ] If applicable, I have revised or added documentation (readme, code comments) so others can understand & reproduce the changes.
  - [ ] If docs are added, I have described them in the "Summarize the changes" section above.
- [x] I will assign reviewer(s) under `Reviewers` in the PR sidebar, not Assignees, so they get email notifications ([doc](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)).

## Reviewer's non-exhaustive checklist during review

- [ ] I understand [how to review a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request#starting-a-review) ([more comprehensive guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests)).
- [ ] This PR closes a task. If not specified, PR creator explains it clearly.
- [ ] The title & change description reflect what the changes intend to do, and I understand it.
- [ ] I look at every line of non-generated code & understand what the code or other changes intend to do, including the naming of everything, comments, consistent style, and simple design.
- [ ] I can reproduce the changes with existing or changed documentation: Setting up dev environment, running programs, and how to use.
- [ ] Finally, I leave comments on encouragement and appreciation for good practices by the PR creator.
